### PR TITLE
Move from "rebar3 edoc" to "rebar3_ex_doc"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         id: setup-beam
         with:
           otp-version: ${{matrix.otp_vsn}}
-          rebar3-version: '3.16'
+          rebar3-version: '3.18'
       - name: restore _build
         uses: actions/cache@v2
         with:
@@ -34,3 +34,5 @@ jobs:
           path: ~/.cache/rebar3
           key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - run: make version
+      - run: make ex_doc-dry
+        if: ${{matrix.otp_vsn >= 24}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .rebar3
 _build
+doc
 erl_crash.dump
 log
 rebar3.crashdump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) from
 the version that will follow 2.1.0.
 
+## [Unreleased]
+
+### Added
+
+- `rebar3_ex_doc` + `make ex_doc-dry` [Paulo Oliveira]
+
+### Changed
+
+- `edoc`-based doc. to `ex_doc`-based doc. [Paulo Oliveira]
+
 ## [3.0.0] - 2021-07-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ shell-slave: epmd
 	@rebar3 as dev do shell --name gen_rpc_slave@127.0.0.1 --config test/gen_rpc.slave.config
 .PHONY: shell-slave
 
-version: upgrade clean compile check test edoc
+version: upgrade clean compile check test
 .PHONY: version
 
-upgrade: upgrade-rebar3_lint upgrade-rebar3_hex upgrade-rebar3_hank
-	@rebar3 do unlock,upgrade
+upgrade: upgrade-rebar3_lint upgrade-rebar3_hex upgrade-rebar3_hank upgrade-rebar3_ex_doc
+	@rebar3 do unlock --all, upgrade --all
 .PHONY: upgrade
 
 upgrade-rebar3_lint:
@@ -37,6 +37,10 @@ upgrade-rebar3_hex:
 upgrade-rebar3_hank:
 	@rebar3 plugins upgrade rebar3_hank
 .PHONY: upgrade-rebar3_hank
+
+upgrade-rebar3_ex_doc:
+	@rebar3 plugins upgrade rebar3_ex_doc
+.PHONY: upgrade-rebar3_ex_doc
 
 clean:
 	@rebar3 clean -a
@@ -95,6 +99,6 @@ epmd:
 	epmd -daemon
 .PHONY: epmd
 
-edoc:
-	@rebar3 edoc
-.PHONY: edoc
+ex_doc-dry:
+	@rebar3 hex publish docs --dry-run
+.PHONY: ex_doc-dry

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!overview.edoc

--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,7 @@
 ]}.
 
 {project_plugins, [
+    rebar3_ex_doc,
     rebar3_hank,
     rebar3_hex,
     rebar3_lint
@@ -47,9 +48,10 @@
 
 {hank, [
     {ignore, [
-        {"**", unused_configuration_options, [ssl_client_port, tcp_client_port]},
-        {"**", unused_callbacks, [all]},
-        {"test/**", unnecessary_function_arguments}
+        {"src/**", unused_configuration_options, [ssl_client_port, tcp_client_port]},
+        {"src/**", unused_callbacks, [all]},
+        {"test/**", unnecessary_function_arguments},
+        {"test/**", unused_configuration_options, [ssl_client_port, tcp_client_port]}
     ]}
 ]}.
 
@@ -90,6 +92,7 @@
             ]}
         ]},
         {deps, [
+            {cth_readable, "v1.5.1"},
             {lager, "3.9.2"}
         ]},
         {dialyzer, [
@@ -98,7 +101,8 @@
                 eunit,
                 lager,
                 ssl_verify_fun
-            ]}
+            ]},
+            {plt_extra_apps, [cth_readable]}
         ]},
         {erl_opts, [
             debug_info,
@@ -117,9 +121,19 @@
     ]}
 ]}.
 
-%% == EDoc ==
+%% == ex_doc ==
 
-{edoc_opts, [
-    {includes, ["src"]},
-    {preprocess, true}
+{ex_doc, [
+    {extras, [
+        {'README.md', #{ title => <<"Overview">> }},
+        {'CHANGELOG.md', #{ title => <<"Changelog">> }},
+        {'CONTRIBUTING.md', #{ title => <<"Contributing">> }},
+        {'LICENSE', #{ title => <<"License">> }}
+    ]},
+    {main, [<<"readme">>]}
+]}.
+{hex, [
+    {doc, #{
+        provider => ex_doc
+    }}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -98,11 +98,11 @@
         {dialyzer, [
             {plt_extra_apps, [
                 common_test,
+                cth_readable,
                 eunit,
                 lager,
                 ssl_verify_fun
-            ]},
-            {plt_extra_apps, [cth_readable]}
+            ]}
         ]},
         {erl_opts, [
             debug_info,

--- a/src/driver/gen_rpc_driver_ssl.erl
+++ b/src/driver/gen_rpc_driver_ssl.erl
@@ -16,11 +16,11 @@
 %%% Include the HUT library
 -include_lib("hut/include/hut.hrl").
 %%% Include this library's name macro
--include("app.hrl").
+-include("../app.hrl").
 %%% Include TCP macros
--include("tcp.hrl").
+-include("../tcp.hrl").
 %%% Include helpful guard macros
--include("guards.hrl").
+-include("../guards.hrl").
 
 %%% Public API
 -export([connect/2,

--- a/src/driver/gen_rpc_driver_tcp.erl
+++ b/src/driver/gen_rpc_driver_tcp.erl
@@ -16,11 +16,11 @@
 %%% Include the HUT library
 -include_lib("hut/include/hut.hrl").
 %%% Include this library's name macro
--include("app.hrl").
+-include("../app.hrl").
 %%% Include TCP macros
--include("tcp.hrl").
+-include("../tcp.hrl").
 %%% Include helpful guard macros
--include("guards.hrl").
+-include("../guards.hrl").
 
 %%% Public API
 -export([connect/2,

--- a/src/supervisor/gen_rpc_client_sup.erl
+++ b/src/supervisor/gen_rpc_client_sup.erl
@@ -14,9 +14,9 @@
 %%% Include the HUT library
 -include_lib("hut/include/hut.hrl").
 %%% Include helpful guard macros
--include("guards.hrl").
+-include("../guards.hrl").
 %%% Include helpful guard macros
--include("types.hrl").
+-include("../types.hrl").
 
 %%% Supervisor functions
 -export([start_link/0]).


### PR DESCRIPTION
I'm aware this implies Erlang/OTP 24+ and `rebar3` 3.18+ (because of `--all`) but I call it "the price of embracing innovation in technology and user experience."